### PR TITLE
Changed program.js to pass promise and deal with the promise in proxy.js

### DIFF
--- a/src/program.js
+++ b/src/program.js
@@ -51,14 +51,6 @@ Program = function (command) {
 
         db = mysql.createConnection(config);
 
-        // Deficiency in the current promise-mysql API requires monkey-patching.
-        // https://github.com/lukeb-uk/node-promise-mysql/issues/3
-        db.query = function (sql, values) {
-            return db.then(function (connection) {
-                return connection.query(sql, values);
-            });
-        };
-
         return db;
     };
 


### PR DESCRIPTION
The monkey patch in program.js is unnecessary and can in fact cause a race condition if the proxy tries to log something to the database before the connection has successfully completed.

By using the promise returned by promise-mysql, the server will only initialise after the DB bas been connected. In the case that the DB isn't being used, Promise.join() will still resolve and start the server.
